### PR TITLE
Fix broken link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ To make use of Citron, we should:
     inputs. We can optionally use Citron's lexer to generate the inputs
     for the parser.
 
-    See [_The Parsing Interface_](parsing-interface/) for information on
+    See [_The Parsing Interface_](parser-interface/) for information on
     how we can use the parser in our code.
 
 ## Examples


### PR DESCRIPTION
I found a broken link and fixed it 👍 

### As-is

http://roopc.net/citron/parsing-interface/

### To-be

http://roopc.net/citron/parser-interface/