### PR TITLE
Squash a warning

### DIFF
--- a/src/CitronParser.swift
+++ b/src/CitronParser.swift
@@ -815,7 +815,7 @@ private extension CitronParser {
                         print(", symbol: \"\(symbolString)\"", terminator: "")
                     }
                 }
-                defer {
+                do {
                     print(")")
                 }
             }


### PR DESCRIPTION
```
warning: 'defer' statement at end of scope always executes immediately; replace with 'do' statement to silence this warning
                defer {
                ^~~~~
                do
```