### PR TITLE
Add a build tool plugin and build the examples with it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "CitronLexerModule", targets: ["CitronLexerModule"]),
     ],
     targets: [
-        .target(name: "citron"),
+        .executableTarget(name: "citron"),
         .target(name: "CitronParserModule", exclude: ["LICENSE.txt"]),
         .target(name: "CitronLexerModule", exclude: ["LICENSE.txt"]),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -6,24 +6,13 @@ import PackageDescription
 let package = Package(
     name: "citron",
     products: [
-        .executable(
-            name: "citron",
-            targets: ["citron"]),
-        .library(
-            name: "CitronParserModule",
-            targets: ["CitronParserModule"]),
-        .library(
-            name: "CitronLexerModule",
-            targets: ["CitronLexerModule"]),
+        .executable(name: "citron", targets: ["citron"]),
+        .library(name: "CitronParserModule", targets: ["CitronParserModule"]),
+        .library(name: "CitronLexerModule", targets: ["CitronLexerModule"]),
     ],
     targets: [
-        .target(
-            name: "citron"),
-        .target(
-            name: "CitronParserModule",
-            exclude: ["LICENSE.txt"]),
-        .target(
-            name: "CitronLexerModule",
-            exclude: ["LICENSE.txt"]),
+        .target(name: "citron"),
+        .target(name: "CitronParserModule", exclude: ["LICENSE.txt"]),
+        .target(name: "CitronLexerModule", exclude: ["LICENSE.txt"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,5 +18,11 @@ let package = Package(
       .plugin(
         name: "CitronParserGenerator", capability: .buildTool(),
         dependencies: ["citron"]),
+
+      .executableTarget(
+        name: "expr",
+        dependencies: ["CitronParserModule", "CitronLexerModule"],
+        path: "examples/expr",
+        plugins: [.plugin(name: "CitronParserGenerator")])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,12 @@ let package = Package(
         name: "expr",
         dependencies: ["CitronParserModule", "CitronLexerModule"],
         path: "examples/expr",
-        plugins: [.plugin(name: "CitronParserGenerator")])
+        plugins: [.plugin(name: "CitronParserGenerator")]),
+
+      .executableTarget(
+        name: "expr_ec",
+        dependencies: ["CitronParserModule", "CitronLexerModule"],
+        path: "examples/expr_ec",
+        plugins: [.plugin(name: "CitronParserGenerator")]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,14 @@ let package = Package(
         .executable(name: "citron", targets: ["citron"]),
         .library(name: "CitronParserModule", targets: ["CitronParserModule"]),
         .library(name: "CitronLexerModule", targets: ["CitronLexerModule"]),
+        .plugin(name: "CitronParserGenerator", targets: ["CitronParserGenerator"])
     ],
     targets: [
-        .executableTarget(name: "citron"),
-        .target(name: "CitronParserModule", exclude: ["LICENSE.txt"]),
-        .target(name: "CitronLexerModule", exclude: ["LICENSE.txt"]),
+      .executableTarget(name: "citron"),
+      .target(name: "CitronParserModule", exclude: ["LICENSE.txt"]),
+      .target(name: "CitronLexerModule", exclude: ["LICENSE.txt"]),
+      .plugin(
+        name: "CitronParserGenerator", capability: .buildTool(),
+        dependencies: ["citron"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,16 +19,33 @@ let package = Package(
         name: "CitronParserGenerator", capability: .buildTool(),
         dependencies: ["citron"]),
 
+      // Examples
       .executableTarget(
         name: "expr",
         dependencies: ["CitronParserModule", "CitronLexerModule"],
         path: "examples/expr",
+        exclude: ["README.md", "Makefile"],
         plugins: [.plugin(name: "CitronParserGenerator")]),
 
       .executableTarget(
         name: "expr_ec",
         dependencies: ["CitronParserModule", "CitronLexerModule"],
         path: "examples/expr_ec",
+        exclude: ["README.md", "Makefile"],
+        plugins: [.plugin(name: "CitronParserGenerator")]),
+
+      .executableTarget(
+        name: "functype",
+        dependencies: ["CitronParserModule", "CitronLexerModule"],
+        path: "examples/functype",
+        exclude: ["README.md", "Makefile"],
+        plugins: [.plugin(name: "CitronParserGenerator")]),
+
+      .executableTarget(
+        name: "functype_ec",
+        dependencies: ["CitronParserModule", "CitronLexerModule"],
+        path: "examples/functype_ec",
+        exclude: ["README.md", "Makefile"],
         plugins: [.plugin(name: "CitronParserGenerator")]),
     ]
 )

--- a/Plugins/CitronParserGenerator/CitronParserGenerator.swift
+++ b/Plugins/CitronParserGenerator/CitronParserGenerator.swift
@@ -1,0 +1,22 @@
+import PackagePlugin
+
+@main
+struct CitronParserGenerator: BuildToolPlugin {
+
+  func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+    guard let target = target as? SourceModuleTarget else { return [] }
+    let inputFiles = target.sourceFiles.filter({ [ "citron", "y"].contains($0.path.extension) })
+    return try inputFiles.map {
+      let inputFile = $0
+      let inputPath = inputFile.path
+      let outputName = inputPath.stem + ".swift"
+      let outputPath = context.pluginWorkDirectory.appending(outputName)
+      return .buildCommand(
+        displayName: "Generating \(outputName) from \(inputPath.lastComponent)",
+        executable: try context.tool(named: "citron").path,
+        arguments: [ "\(inputPath)", "-o", "\(outputPath)" ],
+        inputFiles: [ inputPath, ],
+        outputFiles: [ outputPath ]
+      )
+    }
+  }}

--- a/examples/expr/ArithmeticExpressionParser.y
+++ b/examples/expr/ArithmeticExpressionParser.y
@@ -2,6 +2,10 @@
 
 %class_name ArithmeticExpressionParser
 
+%preface {
+  import CitronParserModule
+  import CitronLexerModule
+}
 
 // Type for terminals
 

--- a/examples/expr/main.swift
+++ b/examples/expr/main.swift
@@ -1,3 +1,5 @@
+import CitronLexerModule
+import CitronParserModule
 
 // Parse tree node type
 

--- a/examples/expr_ec/ArithmeticExpressionParser.y
+++ b/examples/expr_ec/ArithmeticExpressionParser.y
@@ -2,6 +2,10 @@
 
 %class_name ArithmeticExpressionParser
 
+%preface {
+  import CitronParserModule
+  import CitronLexerModule
+}
 
 // Type for terminals
 

--- a/examples/expr_ec/main.swift
+++ b/examples/expr_ec/main.swift
@@ -1,3 +1,5 @@
+import CitronLexerModule
+import CitronParserModule
 
 // Parse tree node type
 

--- a/examples/functype/FunctionHeaderParser.y
+++ b/examples/functype/FunctionHeaderParser.y
@@ -1,6 +1,9 @@
 %class_name FunctionHeaderParser
 
 %preface {
+    import CitronParserModule
+    import CitronLexerModule
+
     enum Token {
         case keyword // for func, throws, inout, etc.
         case punctuation // for (, ), ->, etc.
@@ -13,6 +16,7 @@
         }
     }
     typealias TypeIdentifier = String
+
 }
 
 %token_type Token

--- a/examples/functype/main.swift
+++ b/examples/functype/main.swift
@@ -1,3 +1,6 @@
+import CitronParserModule
+import CitronLexerModule
+
 struct FunctionParameter {
     let localName: String
     let externalName: String?

--- a/examples/functype_ec/ErrorReporter.swift
+++ b/examples/functype_ec/ErrorReporter.swift
@@ -1,3 +1,5 @@
+import CitronParserModule
+import CitronLexerModule
 
 class ErrorReporter {
     let inputString: String

--- a/examples/functype_ec/FunctionHeaderParser.y
+++ b/examples/functype_ec/FunctionHeaderParser.y
@@ -1,6 +1,8 @@
 %class_name FunctionHeaderParser
 
 %preface {
+    import CitronParserModule
+    import CitronLexerModule
     typealias TypeIdentifier = String
 }
 

--- a/examples/functype_ec/main.swift
+++ b/examples/functype_ec/main.swift
@@ -1,3 +1,6 @@
+import CitronParserModule
+import CitronLexerModule
+
 enum Token {
     case keyword // for func, throws, inout, etc.
     case punctuation // for (, ), ->, etc.


### PR DESCRIPTION
This change allows Citron to be used just Swift Package Manager, and no Makefiles