### PR TITLE
Fix more citron.c wrong paths in docs

### DIFF
--- a/docs/generating-the-parser.md
+++ b/docs/generating-the-parser.md
@@ -24,7 +24,7 @@ That would create a Swift file containing the parser class.
 
 The Citron source code is just three files:
 
- 1. **`citron.c`**: The Citron parser generator in C. This contains the
+ 1. **`Sources/citron/main.c`**: The Citron parser generator in C. This contains the
     code to generate a parser class in Swift that implements the
     `CitronParser` protocol.
  

--- a/docs/grammar-file.md
+++ b/docs/grammar-file.md
@@ -175,7 +175,7 @@ We can save this grammar into a grammar file, say
 `grammar.y` and [run citron][run] on the grammar file.
 
 ~~~
-$ clang citron.c -o ./citron
+$ clang Sources/citron/main.c -o ./citron
 $ ./citron grammar.y
 ~~~
 


### PR DESCRIPTION
Follow up: https://github.com/roop/citron/pull/27

cc @roop 